### PR TITLE
stack growth almost done

### DIFF
--- a/include/vm/anon.h
+++ b/include/vm/anon.h
@@ -5,7 +5,7 @@ struct page;
 enum vm_type;
 
 struct anon_page {
-    struct page *page;
+    // struct page *page;
 };
 
 void vm_anon_init (void);

--- a/userprog/exception.c
+++ b/userprog/exception.c
@@ -129,7 +129,6 @@ page_fault (struct intr_frame *f) {
 	bool write;        /* True: access was write, false: access was read. */
 	bool user;         /* True: access by user, false: access by kernel. */
 	void *fault_addr;  /* Fault address. */
-
 	/* Obtain faulting address, the virtual address that was
 	   accessed to cause the fault.  It may point to code or to
 	   data.  It is not necessarily the address of the instruction
@@ -149,6 +148,8 @@ page_fault (struct intr_frame *f) {
 
 #ifdef VM
 	/* For project 3 and later. */
+	thread_current()->stack_pointer = f->rsp;
+
 	if (vm_try_handle_fault (f, fault_addr, user, write, not_present)){
 		return;
 	}

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -835,6 +835,7 @@ lazy_load_segment (struct page *page, void *aux) {
 	if(file_read(lazy->file, page->frame->kva, lazy->read_bytes) != (int) lazy->read_bytes){
 		palloc_free_page(page->frame->kva);	
 		return false;
+		
 	}
 	lock_release(&filesys_lock);
 	//read_bytes로 설정한 이후 부분부터 zero_bytes만큼 0으로 채운다

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -111,6 +111,9 @@ syscall_handler (struct intr_frame *f) {
 	// TODO: Your implementation goes here.
 
 	struct thread *t = thread_current();
+	//페이지 폴트가 커널에서 발생할 경우 intr_frame에서 프로그램의 스택 포인터를 가져오지 못한다
+	//초기 커널모드로 전환할 때 스택 포인터를 쓰레드 구조체에 저장해준다.
+	t->stack_pointer = f->rsp;
 	t->tf = *f;
 
 	// int size = palloc_init();

--- a/vm/build/Makefile
+++ b/vm/build/Makefile
@@ -1,0 +1,64 @@
+# -*- makefile -*-
+
+SRCDIR = ../..
+
+all: os.dsk
+
+include ../../Make.config
+include ../Make.vars
+include ../../tests/Make.tests
+
+# Compiler and assembler options.
+os.dsk: CPPFLAGS += -I$(SRCDIR)/lib/kernel
+
+# Core kernel.
+include ../../threads/targets.mk
+# User process code.
+include ../../userprog/targets.mk
+# Virtual memory code.
+include ../../vm/targets.mk
+# Filesystem code.
+include ../../filesys/targets.mk
+# Library code shared between kernel and user programs.
+include ../../lib/targets.mk
+# Kernel-specific library code.
+include ../../lib/kernel/targets.mk
+# Device driver code.
+include ../../devices/targets.mk
+
+SOURCES = $(foreach dir,$(KERNEL_SUBDIRS),$($(dir)_SRC))
+OBJECTS = $(patsubst %.c,%.o,$(patsubst %.S,%.o,$(SOURCES)))
+DEPENDS = $(patsubst %.o,%.d,$(OBJECTS))
+
+threads/kernel.lds.s: CPPFLAGS += -P
+threads/kernel.lds.s: threads/kernel.lds.S
+
+kernel.o: threads/kernel.lds.s $(OBJECTS)
+	$(LD) $(LDFLAGS) -T $< -o $@ $(OBJECTS)
+
+kernel.bin: kernel.o
+	$(OBJCOPY) -O binary -R .note -R .comment -S $< $@.tmp
+	dd if=$@.tmp of=$@ bs=4096 conv=sync
+	rm $@.tmp
+
+threads/loader.o: threads/loader.S kernel.bin
+	$(CC) -c $< -o $@ $(ASFLAGS) $(CPPFLAGS) $(DEFINES) -DKERNEL_LOAD_PAGES=`perl -e 'print +(-s "kernel.bin") / 4096;'`
+
+loader.bin: threads/loader.o
+	$(LD) $(LDFLAGS) -N -e start -Ttext 0x7c00 --oformat binary -o $@ $<
+
+os.dsk: loader.bin kernel.bin
+	cat $^ > $@
+
+clean::
+	rm -f $(OBJECTS) $(DEPENDS)
+	rm -f threads/loader.o threads/kernel.lds.s threads/loader.d
+	rm -f kernel.o kernel.lds.s
+	rm -f kernel.bin loader.bin os.dsk
+	rm -f bochsout.txt bochsrc.txt
+	rm -f results grade
+
+Makefile: $(SRCDIR)/Makefile.build
+	cp $< $@
+
+-include $(DEPENDS)


### PR DESCRIPTION
pass tests/userprog/args-none
pass tests/userprog/args-single
pass tests/userprog/args-multiple
pass tests/userprog/args-many
pass tests/userprog/args-dbl-space
pass tests/userprog/halt
pass tests/userprog/exit
pass tests/userprog/create-normal
pass tests/userprog/create-empty
pass tests/userprog/create-null
pass tests/userprog/create-bad-ptr
pass tests/userprog/create-long
pass tests/userprog/create-exists
pass tests/userprog/create-bound
pass tests/userprog/open-normal
pass tests/userprog/open-missing
pass tests/userprog/open-boundary
pass tests/userprog/open-empty
pass tests/userprog/open-null
pass tests/userprog/open-bad-ptr
pass tests/userprog/open-twice
pass tests/userprog/close-normal
pass tests/userprog/close-twice
pass tests/userprog/close-bad-fd
pass tests/userprog/read-normal
pass tests/userprog/read-bad-ptr
FAIL tests/userprog/read-boundary
pass tests/userprog/read-zero
pass tests/userprog/read-stdout
pass tests/userprog/read-bad-fd
pass tests/userprog/write-normal
pass tests/userprog/write-bad-ptr
pass tests/userprog/write-boundary
pass tests/userprog/write-zero
pass tests/userprog/write-stdin
pass tests/userprog/write-bad-fd
FAIL tests/userprog/fork-once
FAIL tests/userprog/fork-multiple
FAIL tests/userprog/fork-recursive
FAIL tests/userprog/fork-read
FAIL tests/userprog/fork-close
FAIL tests/userprog/fork-boundary
pass tests/userprog/exec-once
FAIL tests/userprog/exec-arg
FAIL tests/userprog/exec-boundary
pass tests/userprog/exec-missing
pass tests/userprog/exec-bad-ptr
FAIL tests/userprog/exec-read
FAIL tests/userprog/wait-simple
FAIL tests/userprog/wait-twice
FAIL tests/userprog/wait-killed
pass tests/userprog/wait-bad-pid
FAIL tests/userprog/multi-recurse
FAIL tests/userprog/multi-child-fd
pass tests/userprog/rox-simple
FAIL tests/userprog/rox-child
FAIL tests/userprog/rox-multichild
pass tests/userprog/bad-read
pass tests/userprog/bad-write
pass tests/userprog/bad-read2
pass tests/userprog/bad-write2
pass tests/userprog/bad-jump
pass tests/userprog/bad-jump2
pass tests/vm/pt-grow-stack
pass tests/vm/pt-grow-bad
pass tests/vm/pt-big-stk-obj
pass tests/vm/pt-bad-addr
pass tests/vm/pt-bad-read
pass tests/vm/pt-write-code
FAIL tests/vm/pt-write-code2
FAIL tests/vm/pt-grow-stk-sc
pass tests/vm/page-linear
FAIL tests/vm/page-parallel
FAIL tests/vm/page-merge-seq
FAIL tests/vm/page-merge-par
FAIL tests/vm/page-merge-stk
FAIL tests/vm/page-merge-mm
pass tests/vm/page-shuffle
FAIL tests/vm/mmap-read
FAIL tests/vm/mmap-close
FAIL tests/vm/mmap-unmap
FAIL tests/vm/mmap-overlap
FAIL tests/vm/mmap-twice
FAIL tests/vm/mmap-write
pass tests/vm/mmap-ro
FAIL tests/vm/mmap-exit
FAIL tests/vm/mmap-shuffle
FAIL tests/vm/mmap-bad-fd
FAIL tests/vm/mmap-clean
FAIL tests/vm/mmap-inherit
FAIL tests/vm/mmap-misalign
FAIL tests/vm/mmap-null
FAIL tests/vm/mmap-over-code
FAIL tests/vm/mmap-over-data
FAIL tests/vm/mmap-over-stk
FAIL tests/vm/mmap-remove
pass tests/vm/mmap-zero
FAIL tests/vm/mmap-bad-fd2
FAIL tests/vm/mmap-bad-fd3
FAIL tests/vm/mmap-zero-len
FAIL tests/vm/mmap-off
FAIL tests/vm/mmap-bad-off
FAIL tests/vm/mmap-kernel
FAIL tests/vm/lazy-file
pass tests/vm/lazy-anon
FAIL tests/vm/swap-file
FAIL tests/vm/swap-anon
FAIL tests/vm/swap-iter
FAIL tests/vm/swap-fork
pass tests/filesys/base/lg-create
pass tests/filesys/base/lg-full
pass tests/filesys/base/lg-random
pass tests/filesys/base/lg-seq-block
pass tests/filesys/base/lg-seq-random
pass tests/filesys/base/sm-create
pass tests/filesys/base/sm-full
pass tests/filesys/base/sm-random
pass tests/filesys/base/sm-seq-block
pass tests/filesys/base/sm-seq-random
FAIL tests/filesys/base/syn-read
pass tests/filesys/base/syn-remove
FAIL tests/filesys/base/syn-write
pass tests/threads/alarm-single
pass tests/threads/alarm-multiple
pass tests/threads/alarm-simultaneous
pass tests/threads/alarm-priority
pass tests/threads/alarm-zero
pass tests/threads/alarm-negative
pass tests/threads/priority-change
pass tests/threads/priority-donate-one
pass tests/threads/priority-donate-multiple
pass tests/threads/priority-donate-multiple2
pass tests/threads/priority-donate-nest
pass tests/threads/priority-donate-sema
pass tests/threads/priority-donate-lower
pass tests/threads/priority-fifo
pass tests/threads/priority-preempt
pass tests/threads/priority-sema
pass tests/threads/priority-condvar
pass tests/threads/priority-donate-chain
FAIL tests/vm/cow/cow-simple
55 of 141 tests failed.