### PR TITLE
4/141 failed

### DIFF
--- a/include/vm/anon.h
+++ b/include/vm/anon.h
@@ -4,11 +4,22 @@
 struct page;
 enum vm_type;
 
+//implementation
+// struct list swap_table;
+
+// struct swap_table_entry{
+//     struct list_elem swap_elem;
+//     bool is_swapped;
+//     void* va;
+// };
+
 struct anon_page {
-    // struct page *page;
+    // struct swap_table_entry *ste;
 };
 
 void vm_anon_init (void);
 bool anon_initializer (struct page *page, enum vm_type type, void *kva);
+
+
 
 #endif

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -8,6 +8,7 @@
 struct lock page_lock;
 struct list frame_list;
 
+
 enum vm_type {
 	/* page not initialized */
 	VM_UNINIT = 0,
@@ -54,7 +55,7 @@ struct page {
 	/* Your implementation */
 	struct hash_elem hash_elem;
 	bool writable;
-	int mapped_page_count;
+	int pgcount;
 	/* Per-type data are binded into the union.
 	 * Each function automatically detects the current union */
 	union {

--- a/tests/vm/pt-grow-stk-sc.c
+++ b/tests/vm/pt-grow-stk-sc.c
@@ -26,7 +26,6 @@ test_main (void)
   /* Read back via read(). */
   CHECK ((handle = open ("sample.txt")) > 1, "2nd open \"sample.txt\"");
   CHECK (read (handle, buf2 + 32768, slen) == slen, "read \"sample.txt\"");
-  
   CHECK (!memcmp (sample, buf2 + 32768, slen), "compare written data against read data");
   close (handle);
 }

--- a/threads/init.c
+++ b/threads/init.c
@@ -107,7 +107,6 @@ main (void) {
 
 #ifdef FILESYS
 	/* Initialize file system. */
-	
 	disk_init ();
 	filesys_init (format_filesys);
 #endif

--- a/userprog/exception.c
+++ b/userprog/exception.c
@@ -148,7 +148,12 @@ page_fault (struct intr_frame *f) {
 
 #ifdef VM
 	/* For project 3 and later. */
-	thread_current()->stack_pointer = f->rsp;
+	//page_fault내에서는 해당 값을 넣어주면 안된다. 시스템 콜에서 페이지 폴트를 호출할 경우, 여기서 받는 f는 다르기 때문이다! 
+	// thread_current()->stack_pointer = f->rsp;
+	//그렇다면, 아래와 같이 바꿔볼 수 있지 않을까 싶다:
+	if(user){
+		thread_current()->stack_pointer = f->rsp;
+	}
 
 	if (vm_try_handle_fault (f, fault_addr, user, write, not_present)){
 		return;

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -382,8 +382,6 @@ int read (int fd, void *buffer, unsigned size)
 	else
 	{
 		lock_acquire(&filesys_lock);
-
-
 		for (start = list_begin(&curr->fd_table); start != list_end(&curr->fd_table); start = list_next(start))
 		{
 			struct file_descriptor *read_fd = list_entry(start, struct file_descriptor, fd_elem);
@@ -399,6 +397,7 @@ int read (int fd, void *buffer, unsigned size)
 				}
 				buff_size = file_read(read_fd->file, buffer, size);
 			}
+			
 		}
 		lock_release(&filesys_lock);
 	}

--- a/vm/anon.c
+++ b/vm/anon.c
@@ -21,9 +21,12 @@ static const struct page_operations anon_ops = {
 void
 vm_anon_init (void) {
 	/* TODO: Set up the swap_disk. */
-	swap_disk = disk_get(1:1);
+	swap_disk = disk_get(1,1); //swapdisk 로 쓸 때 1:1
 
-}
+	// disk_sector_t *disk_capacity = (disk_sector_t*)malloc(4096);
+	// swap_disk->disk_capacity = disk_capacity;
+
+}	
 
 /* Initialize the file mapping */
 bool
@@ -33,6 +36,7 @@ anon_initializer (struct page *page, enum vm_type type, void *kva) {
 	// page->anon.page = page; 
 
 	struct anon_page *anon_page = &page->anon;
+	// anon_page->ste->is_swapped = 0; 
 }
 
 /* Swap in the page by read contents from the swap disk. */
@@ -45,6 +49,9 @@ anon_swap_in (struct page *page, void *kva) {
 static bool
 anon_swap_out (struct page *page) {
 	struct anon_page *anon_page = &page->anon;
+
+	// disk_write(&swap_disk, );
+	// list_push_back(&swap_table, &anon_page->ste->swap_elem);
 }
 
 /* Destroy the anonymous page. PAGE will be freed by the caller. */

--- a/vm/build/Makefile
+++ b/vm/build/Makefile
@@ -1,0 +1,64 @@
+# -*- makefile -*-
+
+SRCDIR = ../..
+
+all: os.dsk
+
+include ../../Make.config
+include ../Make.vars
+include ../../tests/Make.tests
+
+# Compiler and assembler options.
+os.dsk: CPPFLAGS += -I$(SRCDIR)/lib/kernel
+
+# Core kernel.
+include ../../threads/targets.mk
+# User process code.
+include ../../userprog/targets.mk
+# Virtual memory code.
+include ../../vm/targets.mk
+# Filesystem code.
+include ../../filesys/targets.mk
+# Library code shared between kernel and user programs.
+include ../../lib/targets.mk
+# Kernel-specific library code.
+include ../../lib/kernel/targets.mk
+# Device driver code.
+include ../../devices/targets.mk
+
+SOURCES = $(foreach dir,$(KERNEL_SUBDIRS),$($(dir)_SRC))
+OBJECTS = $(patsubst %.c,%.o,$(patsubst %.S,%.o,$(SOURCES)))
+DEPENDS = $(patsubst %.o,%.d,$(OBJECTS))
+
+threads/kernel.lds.s: CPPFLAGS += -P
+threads/kernel.lds.s: threads/kernel.lds.S
+
+kernel.o: threads/kernel.lds.s $(OBJECTS)
+	$(LD) $(LDFLAGS) -T $< -o $@ $(OBJECTS)
+
+kernel.bin: kernel.o
+	$(OBJCOPY) -O binary -R .note -R .comment -S $< $@.tmp
+	dd if=$@.tmp of=$@ bs=4096 conv=sync
+	rm $@.tmp
+
+threads/loader.o: threads/loader.S kernel.bin
+	$(CC) -c $< -o $@ $(ASFLAGS) $(CPPFLAGS) $(DEFINES) -DKERNEL_LOAD_PAGES=`perl -e 'print +(-s "kernel.bin") / 4096;'`
+
+loader.bin: threads/loader.o
+	$(LD) $(LDFLAGS) -N -e start -Ttext 0x7c00 --oformat binary -o $@ $<
+
+os.dsk: loader.bin kernel.bin
+	cat $^ > $@
+
+clean::
+	rm -f $(OBJECTS) $(DEPENDS)
+	rm -f threads/loader.o threads/kernel.lds.s threads/loader.d
+	rm -f kernel.o kernel.lds.s
+	rm -f kernel.bin loader.bin os.dsk
+	rm -f bochsout.txt bochsrc.txt
+	rm -f results grade
+
+Makefile: $(SRCDIR)/Makefile.build
+	cp $< $@
+
+-include $(DEPENDS)

--- a/vm/file.c
+++ b/vm/file.c
@@ -95,7 +95,7 @@ do_mmap (void *addr, size_t length, int writable,
 
 	void* return_address = addr;
 	
-    int total_page_count = length <= PGSIZE ? 1 : length % PGSIZE ? length / PGSIZE + 1: length / PGSIZE; 
+    int total_pgcount = length <= PGSIZE ? 1 : length % PGSIZE ? length / PGSIZE + 1: length / PGSIZE; 
 
 	// 파일의 길이에 따라서 읽을 바이트 수 결정 
 	size_t read_bytes;
@@ -130,7 +130,7 @@ do_mmap (void *addr, size_t length, int writable,
 		}		
 
 		struct page *p = spt_find_page(&thread_current()->spt, return_address);
-        p->mapped_page_count = total_page_count;
+        p->pgcount = total_pgcount;
 		/* Advance. */
 		read_bytes -= page_read_bytes;
 		zero_bytes -= page_zero_bytes;
@@ -172,7 +172,7 @@ do_munmap (void *addr)
 
     struct supplemental_page_table *spt = &thread_current()->spt;
     struct page *page = spt_find_page(spt, addr);
-    int count = page->mapped_page_count;
+    int count = page->pgcount;
     for (int i = 0; i < count; i++)
     {
         if (page)


### PR DESCRIPTION
pass tests/userprog/args-none
pass tests/userprog/args-single
pass tests/userprog/args-multiple
pass tests/userprog/args-many
pass tests/userprog/args-dbl-space
pass tests/userprog/halt
pass tests/userprog/exit
pass tests/userprog/create-normal
pass tests/userprog/create-empty
pass tests/userprog/create-null
pass tests/userprog/create-bad-ptr
pass tests/userprog/create-long
pass tests/userprog/create-exists
pass tests/userprog/create-bound
pass tests/userprog/open-normal
pass tests/userprog/open-missing
pass tests/userprog/open-boundary
pass tests/userprog/open-empty
pass tests/userprog/open-null
pass tests/userprog/open-bad-ptr
pass tests/userprog/open-twice
pass tests/userprog/close-normal
pass tests/userprog/close-twice
pass tests/userprog/close-bad-fd
pass tests/userprog/read-normal
pass tests/userprog/read-bad-ptr
pass tests/userprog/read-boundary
pass tests/userprog/read-zero
pass tests/userprog/read-stdout
pass tests/userprog/read-bad-fd
pass tests/userprog/write-normal
pass tests/userprog/write-bad-ptr
pass tests/userprog/write-boundary
pass tests/userprog/write-zero
pass tests/userprog/write-stdin
pass tests/userprog/write-bad-fd
pass tests/userprog/fork-once
pass tests/userprog/fork-multiple
pass tests/userprog/fork-recursive
pass tests/userprog/fork-read
pass tests/userprog/fork-close
pass tests/userprog/fork-boundary
pass tests/userprog/exec-once
pass tests/userprog/exec-arg
pass tests/userprog/exec-boundary
pass tests/userprog/exec-missing
pass tests/userprog/exec-bad-ptr
pass tests/userprog/exec-read
pass tests/userprog/wait-simple
pass tests/userprog/wait-twice
pass tests/userprog/wait-killed
pass tests/userprog/wait-bad-pid
pass tests/userprog/multi-recurse
pass tests/userprog/multi-child-fd
pass tests/userprog/rox-simple
pass tests/userprog/rox-child
pass tests/userprog/rox-multichild
pass tests/userprog/bad-read
pass tests/userprog/bad-write
pass tests/userprog/bad-read2
pass tests/userprog/bad-write2
pass tests/userprog/bad-jump
pass tests/userprog/bad-jump2
pass tests/vm/pt-grow-stack
pass tests/vm/pt-grow-bad
pass tests/vm/pt-big-stk-obj
pass tests/vm/pt-bad-addr
pass tests/vm/pt-bad-read
pass tests/vm/pt-write-code
pass tests/vm/pt-write-code2
pass tests/vm/pt-grow-stk-sc
pass tests/vm/page-linear
pass tests/vm/page-parallel
pass tests/vm/page-merge-seq
pass tests/vm/page-merge-par
pass tests/vm/page-merge-stk
pass tests/vm/page-merge-mm
pass tests/vm/page-shuffle
pass tests/vm/mmap-read
pass tests/vm/mmap-close
pass tests/vm/mmap-unmap
pass tests/vm/mmap-overlap
pass tests/vm/mmap-twice
pass tests/vm/mmap-write
pass tests/vm/mmap-ro
pass tests/vm/mmap-exit
pass tests/vm/mmap-shuffle
pass tests/vm/mmap-bad-fd
pass tests/vm/mmap-clean
pass tests/vm/mmap-inherit
pass tests/vm/mmap-misalign
pass tests/vm/mmap-null
pass tests/vm/mmap-over-code
pass tests/vm/mmap-over-data
pass tests/vm/mmap-over-stk
pass tests/vm/mmap-remove
pass tests/vm/mmap-zero
pass tests/vm/mmap-bad-fd2
pass tests/vm/mmap-bad-fd3
pass tests/vm/mmap-zero-len
pass tests/vm/mmap-off
pass tests/vm/mmap-bad-off
pass tests/vm/mmap-kernel
pass tests/vm/lazy-file
pass tests/vm/lazy-anon
FAIL tests/vm/swap-file
FAIL tests/vm/swap-anon
FAIL tests/vm/swap-iter
pass tests/vm/swap-fork
pass tests/filesys/base/lg-create
pass tests/filesys/base/lg-full
pass tests/filesys/base/lg-random
pass tests/filesys/base/lg-seq-block
pass tests/filesys/base/lg-seq-random
pass tests/filesys/base/sm-create
pass tests/filesys/base/sm-full
pass tests/filesys/base/sm-random
pass tests/filesys/base/sm-seq-block
pass tests/filesys/base/sm-seq-random
pass tests/filesys/base/syn-read
pass tests/filesys/base/syn-remove
pass tests/filesys/base/syn-write
pass tests/threads/alarm-single
pass tests/threads/alarm-multiple
pass tests/threads/alarm-simultaneous
pass tests/threads/alarm-priority
pass tests/threads/alarm-zero
pass tests/threads/alarm-negative
pass tests/threads/priority-change
pass tests/threads/priority-donate-one
pass tests/threads/priority-donate-multiple
pass tests/threads/priority-donate-multiple2
pass tests/threads/priority-donate-nest
pass tests/threads/priority-donate-sema
pass tests/threads/priority-donate-lower
pass tests/threads/priority-fifo
pass tests/threads/priority-preempt
pass tests/threads/priority-sema
pass tests/threads/priority-condvar
pass tests/threads/priority-donate-chain
FAIL tests/vm/cow/cow-simple
4 of 141 tests failed.